### PR TITLE
chore(biome): $schema を node_modules 相対パスに変更

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.1/schema.json",
+  "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
   "linter": {
     "enabled": true,
     "rules": { "recommended": true }


### PR DESCRIPTION
<!-- GitHub Copilot コードレビューへの指示: このプルリクエストをレビューしてコメントする際には日本語でお願いします。 -->

## 概要
- `biome.json` の `$schema` をリモート URL (`https://biomejs.dev/schemas/2.5.1/schema.json`) から node_modules 相対パス (`./node_modules/@biomejs/biome/configuration_schema.json`) に変更

## 変更内容
- biome バージョンを更新する際に `$schema` の URL を手動で書き換える必要がなくなる

## テスト計画
- 該当なし（設定ファイルの参照先変更のみ）

Closes #36